### PR TITLE
Fixes for the issue: cannot estimate gas; transaction may fail or may require manual gas limit 

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -34,6 +34,7 @@ module.exports = {
             accounts: [PRIVATE_KEY],
             chainId: 42,
             blockConfirmations: 6,
+            gas: 6000000,
         },
         rinkeby: {
             url: RINKEBY_RPC_URL,

--- a/test/staging/FundMe.staging.test.js
+++ b/test/staging/FundMe.staging.test.js
@@ -15,9 +15,7 @@ developmentChains.includes(network.name)
 
           it("allows people to fund and withdraw", async function () {
               await fundMe.fund({ value: sendValue })
-              await fundMe.withdraw({
-                  gasLimit: 100000,
-              })
+              await fundMe.withdraw();
 
               const endingFundMeBalance = await fundMe.provider.getBalance(
                   fundMe.address


### PR DESCRIPTION
While running the staging test, I faced the following issue: cannot estimate gas; the transaction may fail or may require a manual gas limit. I looked into the repo, someone already has updated the `FundMe.staging.test.js` and added the `gasLimit` while calling the `withdraw` function.

```js
await fundMe.withdraw({
      gasLimit: 100000,
})
```
This solution did not resolve the above issue, so I did some research about it and found the solution and that is to specify the `gas` `key/value` to network inside the hardhat.config file.

The following files have been updated:

`1. FundMe.staging.test.js`

removed the gasLimit from the withdraw function while calling.
```js
await fundMe.withdraw();
```

`2. hardhat.config`

added the gas key/value to rinkeby network.

```js
networks: {
    rinkeby: {
      url: process.env.RPC_URL,
      accounts: [process.env.PRIVATE_KEY],
      chainId: 4,
      blockConfirmations: 6,
      gas: 6000000, // gas added here
    },
  },
```
