### PR TITLE
New change on the function of revertedWith

### DIFF
--- a/test/unit/FundMe.test.js
+++ b/test/unit/FundMe.test.js
@@ -141,7 +141,7 @@ const { developmentChains } = require("../../helper-hardhat-config")
                   )
                   await expect(
                       fundMeConnectedContract.withdraw()
-                  ).to.be.revertedWith("FundMe__NotOwner")
+                  ).to.be.revertedWithCustomError(fundMe, 'FundMe__NotOwner')
               })
           })
       })


### PR DESCRIPTION
Hi to the best Blockchain Community in the internet! Im currently doing the testing of withdraw function, and with the version of patrick, today (17/7/2022) the expect function will return this error: 
``` console
AssertionError: Expected transaction to be reverted with reason 'FundMe__NotOwner', but it reverted with a custom error
```

So apparently, chai made some changes and now we have to use revertedWithCustomError()! 
The first parameter should be the contract interface where the custom error is triggered and the second parameter should be the name of but in string type.

Thanks for this amazing course @PatrickAlphaC !!!