### PR TITLE
Update "revertedWith" to "revertedWithCustomError"

### DIFF
--- a/test/unit/FundMe.test.js
+++ b/test/unit/FundMe.test.js
@@ -141,7 +141,7 @@ const { developmentChains } = require("../../helper-hardhat-config")
                   )
                   await expect(
                       fundMeConnectedContract.withdraw()
-                  ).to.be.revertedWith("FundMe__NotOwner")
+                  ).to.be.revertedWithCustomError(fundMe, "FundMe__NotOwner")
               })
           })
       })


### PR DESCRIPTION
The latest Hardhat Chai Matchers plugin provides the new matcher "revertedWithCustomError" in case a custom error is used in the contract. The test will no longer pass if "revertedWith" is used with a string while in the contract a custom error is used, as hardhat will output the following error:"AssertionError: Expected transaction to be reverted with reason 'FundMe__NotOwner', but it reverted with a custom error".