### PR TITLE
Replaced 'network.name' with 'chainId'

### DIFF
--- a/deploy/01-deploy-fund-me.ts
+++ b/deploy/01-deploy-fund-me.ts
@@ -26,7 +26,7 @@ const deployFundMe: DeployFunction = async function (
     args: [ethUsdPriceFeedAddress],
     log: true,
     // we need to wait if on a live network so we can verify properly
-    waitConfirmations: networkConfig[network.name].blockConfirmations || 0,
+    waitConfirmations: networkConfig[chainId].blockConfirmations || 0,
   })
   log(`FundMe deployed at ${fundMe.address}`)
   if (


### PR DESCRIPTION
`network.name` is a string and `networkConfig` uses chainId's (numbers). So it can't find the correct network if we're using `network.name`, because it's defined by the chainId instead of name/string.