### PR TITLE
Wait for transaction to resolve and Add mocha timeout while running staging tests

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -69,4 +69,7 @@ module.exports = {
             1: 0, // similarly on mainnet it will take the first account as deployer. Note though that depending on how hardhat network are configured, the account 0 on one network can be different than on another
         },
     },
+    mocha: {
+        timeout: 500000,
+    },
 }

--- a/test/staging/FundMe.staging.test.js
+++ b/test/staging/FundMe.staging.test.js
@@ -14,8 +14,10 @@ developmentChains.includes(network.name)
           })
 
           it("allows people to fund and withdraw", async function () {
-              await fundMe.fund({ value: sendValue })
-              await fundMe.withdraw();
+              const fundTxResponse = await fundMe.fund({ value: sendValue })
+              await fundTxResponse.wait(1)
+              const withdrawTxResponse = await fundMe.withdraw()
+              await withdrawTxResponse.wait(1)
 
               const endingFundMeBalance = await fundMe.provider.getBalance(
                   fundMe.address


### PR DESCRIPTION
Most of the time, withdraw transaction is failing when running staging test, waiting for one block confirmation resolves this issue.
It fixes #43

Sometimes getting timeout error while running staging test, adding mocha timeout in hardhat.config.js fixes this.