### PR TITLE
check funder is already in funders array or not

### DIFF
--- a/contracts/FundMe.sol
+++ b/contracts/FundMe.sol
@@ -55,8 +55,10 @@ contract FundMe {
             "You need to spend more ETH!"
         );
         // require(PriceConverter.getConversionRate(msg.value) >= MINIMUM_USD, "You need to spend more ETH!");
+        if (s_addressToAmountFunded[msg.sender] == 0) {
+            s_funders.push(msg.sender);
+        }
         s_addressToAmountFunded[msg.sender] += msg.value;
-        s_funders.push(msg.sender);
     }
 
     function withdraw() public onlyOwner {


### PR DESCRIPTION
Right now, if the player enter raffle multiple times, then player address is pushed into the `s_funders` multiple times.
So checking whether player is already in the array and pushing player only after if player is not in the array by adding:
`if (s_addressToAmountFunded[msg.sender] == 0) {
            s_funders.push(msg.sender);`

With this, we are still allowing to enter the same player to enter multiple times but it won't store the player address multiple times.