### PR TITLE
Updated compiler version in PriceConverter

### DIFF
--- a/contracts/PriceConverter.sol
+++ b/contracts/PriceConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.8;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 


### PR DESCRIPTION
As there is already a **solc** version **"0.8.8"** in `hardhat.config.js` and **solc** version **"0.8.0"** is not included in there!