### PR TITLE
Added require("dotenv").config() in deploy script

### DIFF
--- a/deploy/01-deploy-fund-me.js
+++ b/deploy/01-deploy-fund-me.js
@@ -1,6 +1,7 @@
 const { network } = require("hardhat")
 const { networkConfig, developmentChains } = require("../helper-hardhat-config")
 const { verify } = require("../utils/verify")
+require("dotenv").config()
 
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments


### PR DESCRIPTION
Added `require("dotenv").config()` in `01-deploy-fund-me.js` script. As mention in our code.

```javascript
if (
        !developmentChains.includes(network.name) &&
        process.env.ETHERSCAN_API_KEY
    ) {
        await verify(fundMe.address, [ethUsdPriceFeedAddress])
    }
```

we need to have `process.env.ETHERSCAN_API_KEY` to verify our smart contract. So we need to add `require("dotenv").config()`  in order to use  ` process.env.ETHERSCAN_API_KEY `.