### PR TITLE
Added solhint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "solidity-coverage": "^0.7.18",
     "@chainlink/contracts": "^0.3.1",
     "dotenv": "^14.2.0",
-    "prettier-plugin-solidity": "^1.0.0-beta.19"
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
+    "solhint": "^3.3.7",
   },
   "scripts": {
     "test": "hardhat test",


### PR DESCRIPTION
cannot run the solhint scripts without adding solhint. To manually add it, use "yarn add solhint" to your existing package.json