### PR TITLE
fix: package.json unnecessary comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@chainlink/contracts": "^0.3.1",
     "dotenv": "^14.2.0",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
-    "solhint": "^3.3.7",
+    "solhint": "^3.3.7"
   },
   "scripts": {
     "test": "hardhat test",


### PR DESCRIPTION
Running command yarn was triggering "invalid package.json in package.json"