### PR TITLE
ethers version 6 updates

### DIFF
--- a/scripts/fund.js
+++ b/scripts/fund.js
@@ -6,7 +6,7 @@ async function main() {
   console.log(`Got contract FundMe at ${fundMe.address}`)
   console.log("Funding contract...")
   const transactionResponse = await fundMe.fund({
-    value: ethers.utils.parseEther("0.1"),
+    value: ethers.parseEther("0.1"),
   })
   await transactionResponse.wait()
   console.log("Funded!")

--- a/test/staging/FundMe.staging.test.js
+++ b/test/staging/FundMe.staging.test.js
@@ -7,7 +7,7 @@ developmentChains.includes(network.name)
     : describe("FundMe Staging Tests", function () {
           let deployer
           let fundMe
-          const sendValue = ethers.utils.parseEther("0.1")
+          const sendValue = ethers.parseEther("0.1")
           beforeEach(async () => {
               deployer = (await getNamedAccounts()).deployer
               fundMe = await ethers.getContract("FundMe", deployer)

--- a/test/unit/FundMe.test.js
+++ b/test/unit/FundMe.test.js
@@ -8,7 +8,7 @@ const { developmentChains } = require("../../helper-hardhat-config")
           let fundMe
           let mockV3Aggregator
           let deployer
-          const sendValue = ethers.utils.parseEther("1")
+          const sendValue = ethers.parseEther("1")
           beforeEach(async () => {
               // const accounts = await ethers.getSigners()
               // deployer = accounts[0]


### PR DESCRIPTION
parseEther function has been moved from ethers.utils to ethers . Hence , 

In ethers 6 we can use:

ethers.parseEther("")

instead of ethers.utils.parseEther()
