### PR TITLE
fix(priceConverter): Correct multiplication factor in getPrice function

### DIFF
--- a/contracts/PriceConverter.sol
+++ b/contracts/PriceConverter.sol
@@ -11,7 +11,7 @@ library PriceConverter {
   {
     (, int256 answer, , , ) = priceFeed.latestRoundData();
     // ETH/USD rate in 18 digit
-    return uint256(answer * 10000000000);
+    return uint256(answer * 1e18);
   }
 
   // 1000000000


### PR DESCRIPTION
**Description:**
This pull request corrects a potential error in the `getPrice` function within the `PriceConverter` library. The function is responsible for converting the answer from the price feed to a uint256 value representing the ETH/USD rate.

**Changes:**
- Updated the multiplication factor from `10000000000` to `10**18` to ensure that the result is in 18 decimal places.
- This change aligns the function with standard practices for handling decimal values in Ethereum smart contracts.

**Impact:**
- This change ensures the accuracy of the price conversion in contracts utilizing the `PriceConverter` library.
- It resolves potential discrepancies that could arise due to incorrect multiplication factors.

**Reviewer:** @PatrickAlphaC 
