### PR TITLE
Update MockV3Aggregator.sol

### DIFF
--- a/contracts/test/MockV3Aggregator.sol
+++ b/contracts/test/MockV3Aggregator.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity ^0.8.0;
 
-import "@chainlink/contracts/src/v0.6/tests/MockV3Aggregator.sol";
+import "@chainlink/contracts/src/v0.8/tests/MockV3Aggregator.sol";


### PR DESCRIPTION
I think,
```solidity
@chainlink/contracts/src/v0.6 
```
file does not exist anymore, that is why we should use 
```solidity
@chainlink/contracts/src/v0.8 
```
to import MockV3Aggregator.sol and also pragma version should be 
```solidity
pragma solidity ^0.8.0;
```
in the end content of MockV3Aggregator.sol is 
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

import "@chainlink/contracts/src/v0.8/tests/MockV3Aggregator.sol";
```